### PR TITLE
docs: add missing CODE_OF_CONDUCT, document npm test, note coverage gaps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -503,3 +503,7 @@ transforms, snapping, the AI intent/layout/build pipeline (including grid
 detection and playing a turn on an existing board), and the renderer itself (via
 node-canvas, including a determinism check that the same scene renders
 byte-identically twice).
+
+Not covered: the socket server (`server/`), every React component, hook and
+context under `app/`, and the API routes — see [#14](https://github.com/SolomonYakubu/collabdraw/issues/14)
+and [#15](https://github.com/SolomonYakubu/collabdraw/issues/15).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,68 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer by opening an issue in this repository, or
+through any contact method the maintainer publishes on their GitHub profile.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,5 +41,10 @@ If you encounter any issues, please open an issue in the repository with a detai
    ```bash
    npm run dev
    ```
+3. Before opening a pull request, run the test suite:
+   ```bash
+   npm test
+   ```
+   See [README.md](README.md#tests) for what it does and does not cover yet.
 
 Thank you for contributing!

--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ construction, hit testing, bindings, linear elements, the elbow router,
 transforms, snapping and the AI intent/layout/build pipeline — plus the renderer
 itself through node-canvas.
 
+Not yet covered: the socket server (`server/`), every React component, hook and
+context under `app/`, and the API routes — see [#14](https://github.com/SolomonYakubu/collabdraw/issues/14)
+and [#15](https://github.com/SolomonYakubu/collabdraw/issues/15).
+
 ## Contributing
 
 We welcome contributions! Here's how you can help:


### PR DESCRIPTION
## Summary
- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1) — `CONTRIBUTING.md` linked to it but it didn't exist in the repo.
- `CONTRIBUTING.md`'s Development Setup only covered `npm install` and `npm run dev`, so a contributor had no documented way to know they should verify anything before opening a PR. Added `npm test` as step 3, linking to the README's Tests section.
- `README.md` and `ARCHITECTURE.md` both describe Vitest's coverage accurately but omit that the socket server, all React components/hooks/context, and all API routes have none. Added a line to each pointing at #14 and #15, where that gap is already tracked.

Closes #17

## Test plan
- [x] Ran `npm test` per the newly-documented step — 23 test files, 407 tests, all passing
- [x] Verified the `CODE_OF_CONDUCT.md` link in `CONTRIBUTING.md` now resolves